### PR TITLE
[Pagination] Refactor PagePaginationDataResolverTrait according to new StartSizeData.

### DIFF
--- a/packages/Pagination/src/Resolvers/StartSizeAsArrayInQueryResolver.php
+++ b/packages/Pagination/src/Resolvers/StartSizeAsArrayInQueryResolver.php
@@ -7,11 +7,11 @@ use Psr\Http\Message\ServerRequestInterface;
 use StepTheFkUp\Pagination\Interfaces\StartSizeConfigInterface;
 use StepTheFkUp\Pagination\Interfaces\StartSizeDataInterface;
 use StepTheFkUp\Pagination\Interfaces\StartSizeDataResolverInterface;
-use StepTheFkUp\Pagination\Traits\PagePaginationDataResolverTrait;
+use StepTheFkUp\Pagination\Traits\DataResolverTrait;
 
 final class StartSizeAsArrayInQueryResolver implements StartSizeDataResolverInterface
 {
-    use PagePaginationDataResolverTrait;
+    use DataResolverTrait;
 
     /**
      * @var \StepTheFkUp\Pagination\Interfaces\StartSizeConfigInterface
@@ -48,6 +48,6 @@ final class StartSizeAsArrayInQueryResolver implements StartSizeDataResolverInte
     {
         $query = $request->getQueryParams();
 
-        return $this->createPagePaginationData($this->config, $query[$this->queryAttr] ?? []);
+        return $this->createStartSizeData($this->config, $query[$this->queryAttr] ?? []);
     }
 }

--- a/packages/Pagination/src/Resolvers/StartSizeInQueryResolver.php
+++ b/packages/Pagination/src/Resolvers/StartSizeInQueryResolver.php
@@ -7,11 +7,11 @@ use Psr\Http\Message\ServerRequestInterface;
 use StepTheFkUp\Pagination\Interfaces\StartSizeConfigInterface;
 use StepTheFkUp\Pagination\Interfaces\StartSizeDataInterface;
 use StepTheFkUp\Pagination\Interfaces\StartSizeDataResolverInterface;
-use StepTheFkUp\Pagination\Traits\PagePaginationDataResolverTrait;
+use StepTheFkUp\Pagination\Traits\DataResolverTrait;
 
 final class StartSizeInQueryResolver implements StartSizeDataResolverInterface
 {
-    use PagePaginationDataResolverTrait;
+    use DataResolverTrait;
 
     /**
      * @var \StepTheFkUp\Pagination\Interfaces\StartSizeConfigInterface
@@ -37,6 +37,6 @@ final class StartSizeInQueryResolver implements StartSizeDataResolverInterface
      */
     public function resolve(ServerRequestInterface $request): StartSizeDataInterface
     {
-        return $this->createPagePaginationData($this->config, $request->getQueryParams());
+        return $this->createStartSizeData($this->config, $request->getQueryParams());
     }
 }

--- a/packages/Pagination/src/Traits/DataResolverTrait.php
+++ b/packages/Pagination/src/Traits/DataResolverTrait.php
@@ -7,7 +7,7 @@ use StepTheFkUp\Pagination\Data\StartSizeData;
 use StepTheFkUp\Pagination\Interfaces\StartSizeConfigInterface;
 use StepTheFkUp\Pagination\Interfaces\StartSizeDataInterface;
 
-trait PagePaginationDataResolverTrait
+trait DataResolverTrait
 {
     /**
      * Create page pagination data for given data and configuration.
@@ -17,7 +17,7 @@ trait PagePaginationDataResolverTrait
      *
      * @return \StepTheFkUp\Pagination\Interfaces\StartSizeDataInterface
      */
-    private function createPagePaginationData(StartSizeConfigInterface $config, $data): StartSizeDataInterface
+    private function createStartSizeData(StartSizeConfigInterface $config, $data): StartSizeDataInterface
     {
         if (\is_array($data) === false) {
             return new StartSizeData($config->getStartDefault(), $config->getSizeDefault());

--- a/packages/Pagination/src/Traits/PagePaginationDataResolverTrait.php
+++ b/packages/Pagination/src/Traits/PagePaginationDataResolverTrait.php
@@ -24,8 +24,8 @@ trait PagePaginationDataResolverTrait
         }
 
         return new StartSizeData(
-            empty($data[$config->getStartAttribute()]) ? $config->getStartDefault() : $data[$config->getStartAttribute()],
-            empty($data[$config->getSizeAttribute()]) ? $config->getSizeDefault() : $data[$config->getSizeAttribute()]
+            empty($data[$config->getStartAttribute()]) ? $config->getStartDefault() : (int)$data[$config->getStartAttribute()],
+            empty($data[$config->getSizeAttribute()]) ? $config->getSizeDefault() : (int)$data[$config->getSizeAttribute()]
         );
     }
 }

--- a/packages/Pagination/tests/Resolvers/StartSizeAsArrayInQueryResolverTest.php
+++ b/packages/Pagination/tests/Resolvers/StartSizeAsArrayInQueryResolverTest.php
@@ -28,6 +28,25 @@ final class StartSizeAsArrayInQueryResolverTest extends AbstractResolversTestCas
     }
 
     /**
+     * StartSizeAsArrayInQueryResolver should resolve pagination data successfully with string values.
+     *
+     * @return void
+     */
+    public function testCustomConfigResolveWithStringAsValuesSuccessfully(): void
+    {
+        $config = $this->createConfig('page', null, 'perPage');
+        $data = $data = (new StartSizeAsArrayInQueryResolver($config, 'page'))->resolve($this->createServerRequest([
+            'page' => [
+                'page' => '10',
+                'perPage' => '50'
+            ]
+        ]));
+
+        self::assertEquals(10, $data->getStart());
+        self::assertEquals(50, $data->getSize());
+    }
+
+    /**
      * StartSizeAsArrayInQueryResolver should return data with defaults if query attribute not an array.
      *
      * @return void

--- a/packages/Pagination/tests/Resolvers/StartSizeAsArrayInQueryResolverTest.php
+++ b/packages/Pagination/tests/Resolvers/StartSizeAsArrayInQueryResolverTest.php
@@ -35,7 +35,7 @@ final class StartSizeAsArrayInQueryResolverTest extends AbstractResolversTestCas
     public function testCustomConfigResolveWithStringAsValuesSuccessfully(): void
     {
         $config = $this->createConfig('page', null, 'perPage');
-        $data = $data = (new StartSizeAsArrayInQueryResolver($config, 'page'))->resolve($this->createServerRequest([
+        $data = (new StartSizeAsArrayInQueryResolver($config, 'page'))->resolve($this->createServerRequest([
             'page' => [
                 'page' => '10',
                 'perPage' => '50'

--- a/packages/Pagination/tests/Resolvers/StartSizeInQueryResolverTest.php
+++ b/packages/Pagination/tests/Resolvers/StartSizeInQueryResolverTest.php
@@ -17,8 +17,8 @@ final class StartSizeInQueryResolverTest extends AbstractResolversTestCase
     {
         $config = $this->createConfig('page', null, 'perPage');
         $data = (new StartSizeInQueryResolver($config))->resolve($this->createServerRequest([
-            'page' => 5,
-            'perPage' => 100
+            'page' => '5',
+            'perPage' => '100'
         ]));
 
         self::assertEquals(5, $data->getStart());

--- a/packages/Pagination/tests/Resolvers/StartSizeInQueryResolverTest.php
+++ b/packages/Pagination/tests/Resolvers/StartSizeInQueryResolverTest.php
@@ -17,12 +17,29 @@ final class StartSizeInQueryResolverTest extends AbstractResolversTestCase
     {
         $config = $this->createConfig('page', null, 'perPage');
         $data = (new StartSizeInQueryResolver($config))->resolve($this->createServerRequest([
-            'page' => '5',
-            'perPage' => '100'
+            'page' => 5,
+            'perPage' => 100
         ]));
 
         self::assertEquals(5, $data->getStart());
         self::assertEquals(100, $data->getSize());
+    }
+
+    /**
+     * StartSizeInQueryResolver should resolve pagination data successfully with string values.
+     *
+     * @return void
+     */
+    public function testCustomConfigResolveWithStringAsValuesSuccessfully(): void
+    {
+        $config = $this->createConfig('page', null, 'perPage');
+        $data = (new StartSizeInQueryResolver($config))->resolve($this->createServerRequest([
+            'page' => '10',
+            'perPage' => '50'
+        ]));
+
+        self::assertEquals(10, $data->getStart());
+        self::assertEquals(50, $data->getSize());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

- Parameter $data[] can be a request payload which allows string values that should be parsed as integer as an argument.